### PR TITLE
fix: Handle undefined componentProps

### DIFF
--- a/src/actions/query.js
+++ b/src/actions/query.js
@@ -350,6 +350,7 @@ export function executeQuery(
 			if (
 				selectedValues[componentId]
 				&& selectedValues[componentId].reference !== 'URL'
+				&& componentProps
 				&& [
 					componentTypes.reactiveList,
 					componentTypes.reactiveMap,


### PR DESCRIPTION
I was experiencing errors with Appbase's DataGrid component when adding / removing filters causing a `componentProps is undefined` error in React. As far as I can tell, the component ID of the DataGrid results table changes to trigger an update of the results. When debugging, it appears the new componentId is not in the list of props found here: https://github.com/appbaseio/reactivecore/blob/master/src/actions/query.js#L349 . So componentProps is undefined and the following lines don't handle for that.

This change handles that by checking that the value for `componentProps` is not undefined. 